### PR TITLE
RStudio addin for beep()

### DIFF
--- a/R/beepr.R
+++ b/R/beepr.R
@@ -183,3 +183,15 @@ play_file <- function(fname) {
     play_audio(fname)
   }
 }
+
+beeprAddin <- function() {
+  if (requireNamespace("rstudioapi", quietly = TRUE)) {
+    rstudioapi::sendToConsole("beepr::beep()", focus=FALSE)
+  } else {
+    stop(
+      "Package \"rstudioapi\" must be installed to use the beepr addin.",
+      call. = FALSE
+    )
+  }
+  
+}

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -1,0 +1,4 @@
+Name: Play beep
+Description: Run the function `beepr::beep()` in the command line.
+Binding: beeprAddin
+Interactive: false


### PR DESCRIPTION
This is a simple addin that will run `beep()` in the console. You can bind it to a key in RStudio and easily queue up a `beep()` after you've run some code.